### PR TITLE
Install bash completion, move CLI scripts to non-dev package

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -2,7 +2,5 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
-usr/share/gz/*
-usr/lib/ruby/*/*.rb
 usr/lib/*/ruby/*/msgs[0-99]/*
 usr/share/gz/*-msgs*/*-msgs[0-9].tag.xml

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -1,1 +1,3 @@
 usr/lib/*/*.so.*
+usr/lib/ruby/gz/*.rb
+usr/share/gz/*

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -1,3 +1,4 @@
 usr/lib/*/*.so.*
 usr/lib/ruby/gz/*.rb
-usr/share/gz/*
+usr/share/gz/*.yaml
+usr/share/gz/*.completion*/*


### PR DESCRIPTION
* Part of
    * https://github.com/gazebo-tooling/release-tools/issues/529
    * https://github.com/gazebosim/gz-tools/issues/1
* Similar to
    * https://github.com/gazebo-release/gz-msgs5-release/pull/4
    * https://github.com/gazebo-release/gz-msgs5-release/pull/7

Focal: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-msgs9-debbuilder&build=608)](https://build.osrfoundation.org/view/ign-garden/job/gz-msgs9-debbuilder/608/)